### PR TITLE
Add regex rule for failed XML-RPC auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ wp-cli.local.yml
 # Operating system specific files
 .DS_Store
 Thumbs.db
+
+# IDE specific files
+.vscode 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
 
-## [0.9.2](https://github.com/thebrandonallen/wp-fail2ban-redux/tree/0.9.0) - 2024-04-30
+## [0.9.2](https://github.com/thebrandonallen/wp-fail2ban-redux/tree/0.9.2) - 2024-04-30
 ### Changed
 * Add a new regex rule for XMLRPC authentication failure to both filters (soft and hard)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.9.2](https://github.com/thebrandonallen/wp-fail2ban-redux/tree/0.9.0) - 2024-04-30
+### Changed
+* Add a new regex rule for XMLRPC authentication failure to both filters (soft and hard)
+
 ## [0.9.0](https://github.com/thebrandonallen/wp-fail2ban-redux/tree/0.9.0) - 2023-10-17
 ### Changed
 * Bumps "Tested up to" version to 6.4

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ You need to add some code to your `wp-config.php` file. See the below links for 
 
 ## Changelog ##
 
+### 0.9.2 ###
+* Release date: 2024-04-30
+* Add a new regex rule for XMLRPC authentication failure to both filters (soft and hard)
+
 ### 0.9.1 ###
 * Release date: 2023-10-17
 * Bumps "Tested up to" version to 6.4

--- a/config/filters/wordpress-hard.conf
+++ b/config/filters/wordpress-hard.conf
@@ -28,6 +28,7 @@ failregex = ^%(__prefix_line)sAuthentication attempt for unknown user .* from <H
             ^%(__prefix_line)sPingback error .* generated from <HOST>$
             ^%(__prefix_line)sSpammed comment from <HOST>$
             ^%(__prefix_line)sXML-RPC multicall authentication failure from <HOST>$
+			^%(__prefix_line)sXML-RPC authentication failure from <HOST>$
 
 # Option:  ignoreregex
 # Notes.:  regex to ignore. If this regex matches, the line is ignored.

--- a/config/filters/wordpress-soft.conf
+++ b/config/filters/wordpress-soft.conf
@@ -23,6 +23,7 @@ _daemon = wp
 # Values:  TEXT
 #
 failregex = ^%(__prefix_line)sAuthentication failure for .* from <HOST>$
+			^%(__prefix_line)sXML-RPC authentication failure from <HOST>$
 
 # Option:  ignoreregex
 # Notes.:  regex to ignore. If this regex matches, the line is ignored.

--- a/wp-fail2ban-redux.php
+++ b/wp-fail2ban-redux.php
@@ -7,7 +7,7 @@
  * Author URI:        https://github.com/thebrandonallen
  * Text Domain:       wp-fail2ban-redux
  * Domain Path:       /languages
- * Version:           0.9.1
+ * Version:           0.9.2
  * Requires at least: 5.5
  * Requires PHP:      7.0
  * License:           GPLv2 or later


### PR DESCRIPTION
This pull request changes the filter files to include a regex rule for failed XMLRPC authentications. The current regex rules doesn't seem to match simple XMLRPC authentication failures, only multi-call failures. 

On my system (Ubuntu 22.04), I could only trigger "XML-RPC authentication failure from <HOST>" error log, not the "XML-RPC multicall authentication failure from <HOST>" error log. My reasoning: if no "XML-RPC multicall" warning is being logged, then the regex rule would not apply.  Please, let me know if I'm wrong and what is the mistake I'm making (so I can learn and improve!).

If I'm right, this new filter should be enough for the regex to apply. In this case, a mention on the changelog letting people know they need to update their filters would be nice. 

PS. Congrats on this nice plugin! 